### PR TITLE
[msyncd] Use invoker to launch msyncd

### DIFF
--- a/msyncd/bin/msyncd.service
+++ b/msyncd/bin/msyncd.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Sync FW daemon
-Requires=dbus.socket
-After=pre-user-session.target
+Requires=dbus.socket booster-qt5.service
+After=pre-user-session.target booster-qt5.service
 
 [Service]
-ExecStart=/usr/bin/msyncd
+ExecStart=/usr/bin/invoker -s --type=qt5 /usr/bin/msyncd
 Restart=always
 
 [Install]

--- a/msyncd/main.cpp
+++ b/msyncd/main.cpp
@@ -64,7 +64,7 @@ void setLogLevelFromFile()
     }
 }
 
-int main( int argc, char* argv[] )
+Q_DECL_EXPORT int main( int argc, char* argv[] )
 {
     // remove this later on if not needed in harmattan,
     // this IS needed for fremantle

--- a/msyncd/msyncd.pro
+++ b/msyncd/msyncd.pro
@@ -35,6 +35,12 @@ equals(QT_MAJOR_VERSION, 4): {
 equals(QT_MAJOR_VERSION, 5): {
     PKGCONFIG += libsignon-qt5 accounts-qt5 Qt5SystemInfo
     LIBS += -lbuteosyncfw5
+    packagesExist(qt5-boostable) {
+        DEFINES += HAS_BOOSTER
+        PKGCONFIG += qt5-boostable
+    } else {
+        warning("qt5-boostable not available; startup times will be slower")
+    }
 }
 
 QMAKE_LIBDIR_QT += ../libsyncprofile/

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name: buteo-syncfw-qt5
-Version: 0.6.1
+Version: 0.6.15
 Release: 1
 Summary: Synchronization backend
 Group: System/Libraries
@@ -17,6 +17,8 @@ BuildRequires: pkgconfig(accounts-qt5)
 BuildRequires: pkgconfig(libsignon-qt5)
 BuildRequires: pkgconfig(Qt5SystemInfo)
 BuildRequires: pkgconfig(libiphb)
+BuildRequires: pkgconfig(qt5-boostable)
+Requires: mapplauncherd-qt5
 
 %description
 %{summary}.


### PR DESCRIPTION
This allows mapplauncherd to set privileges for msyncd properly.
