### PR TITLE
[msyncd] let plugins see msyncd's symbols

### DIFF
--- a/msyncd/bin/msyncd.service
+++ b/msyncd/bin/msyncd.service
@@ -4,7 +4,9 @@ Requires=dbus.socket booster-qt5.service
 After=pre-user-session.target booster-qt5.service
 
 [Service]
-ExecStart=/usr/bin/invoker -s --type=qt5 /usr/bin/msyncd
+# -G (--global-syms) so that msyncd's plugins can find symbols in msyncd and
+#     in the libraries msyncd is linked to.
+ExecStart=/usr/bin/invoker -G -s --type=qt5 /usr/bin/msyncd
 Restart=always
 
 [Install]


### PR DESCRIPTION
After the change to using invoker to launch msyncd, the fsstorage plugin could no longer find its symbols. Adding -G (--global-syms) to the invoker makes symbol resolution behave the same way as when msyncd is the main program.

This fixes 2 symptoms:
- an assertion failure from msyncd when taking the USB cable out
- inability to see any files from the host (due to fsstorage not loading)
