### PR TITLE
return with real exit code of unit test

### DIFF
--- a/unittests/tests/runstarget.sh
+++ b/unittests/tests/runstarget.sh
@@ -15,6 +15,6 @@ echo "$RESULT is return value of executing ${1}" >> /tmp/$FILE.out
 grep "Totals:" /tmp/$FILE.out >/tmp/$FILE.cmp
 
 # Exit with the same code as the test binary
-#exit $RESULT
+exit $RESULT
 # Exit always with zero until problems in CI environment are resolved
-exit 0
+#exit 0


### PR DESCRIPTION
[qa] return with real exit code of unit test

test case is not useful if it return always with 0 (passed)
