### PR TITLE
Replace accounts sync to syncAndBlock().

### DIFF
--- a/msyncd/AccountsHelper.cpp
+++ b/msyncd/AccountsHelper.cpp
@@ -345,7 +345,7 @@ void AccountsHelper::addAccountIfNotExists(Accounts::Account *account,
         iProfileManager.updateProfile(*newProfile);
 
         account->setValue(KEY_PROFILE_ID, newProfile->name());
-        account->sync();
+        account->syncAndBlock();
 
         emit scheduleUpdated(newProfile->name());
         if(newProfile->isSOCProfile())


### PR DESCRIPTION
Replace accounts sync to syncAndBlock(). accounts object is getting deleted before values are saved to DB
