### PR TITLE
Patch to generate sync profile whenever an account is created

### DIFF
--- a/msyncd/AccountsHelper.h
+++ b/msyncd/AccountsHelper.h
@@ -35,6 +35,8 @@ class AccountsHelperTest;
 class ProfileManager;
 class SyncProfile;
     
+const QString REMOTE_SERVICE_NAME("remote_service_name");
+
 /*! \brief Helper Class towards Accounts::Manager and various SSO related
  *  operations.
  */
@@ -107,6 +109,13 @@ Q_SIGNALS:
 
 private:
 
+    /*!
+     * \brief This method is used to create a profile for a specified
+     * account
+     */
+    void createProfileForAccount(Accounts::Account* account,
+                                 const QString profileName,
+                                 const SyncProfile* baseProfile);
 
     void addAccountIfNotExists(Accounts::Account *account,
                                Accounts::Service service,


### PR DESCRIPTION
Whenever an account that has a sync service is created, this patch
creates a corresponding profile XML for that account. The created
account should have a setting "remote_service_name" the value of which
should be equal to a service domain name. For example, it should be
like "memotoo.com", "yahoo.com" etc. The profile XML files are created
with names like "memotoo-<account id>.com.xml". This value is again set
as an account setting, using which an account can trigger sync

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
