### PR TITLE
Settings are not updated to Accounts when saved in onAccountCreated function

### DIFF
--- a/msyncd/AccountsHelper.h
+++ b/msyncd/AccountsHelper.h
@@ -115,6 +115,8 @@ private:
     void setSyncSchedule(SyncProfile *syncProfile, Accounts::AccountId id, bool aCreateNew = false);
     void registerAccountListeners();
 
+    void addSetting(Accounts::AccountId id, QString key, QVariant value);
+
     void registerAccountListener(Accounts::AccountId id);
 
     Accounts::Manager *iAccountManager;


### PR DESCRIPTION
Settings are not updated to Accounts when saved in onAccountCreated function.

Moved Profile Id saving code to OnAccountEnabled signal.
