### PR TITLE
Added API macros LOG_RESET and SET_BUTEO_LOGGER to enable apps logging

### DIFF
--- a/libbuteosyncfw/common/LogMacros.h
+++ b/libbuteosyncfw/common/LogMacros.h
@@ -45,6 +45,14 @@
 #define LOG_DEBUG(msg) LOG_MSG_L(QtDebugMsg, msg)
 #define LOG_TRACE(msg) LOG_MSG_L(QtDebugMsg, msg)
 #define LOG_TRACE_PLAIN(msg) LOG_MSG_L_PLAIN(QtDebugMsg, msg)
+/*! \brief Resets the Buteo installed logger to the Qt default
+ *! \see SET_BUTEO_LOGGER
+ */
+#define LOG_RESET qInstallMessageHandler(0)
+/*! \brief Sets the logger to Buteo logger again
+ *! \see LOG_RESET
+ */
+#define SET_BUTEO_LOGGER if(Buteo::Logger::instance()->enabled()) Buteo::Logger::setLogLevelFromFile()
 
 /*!
  * Creates a trace message to log when the function is entered and exited.

--- a/libbuteosyncfw/common/Logger.cpp
+++ b/libbuteosyncfw/common/Logger.cpp
@@ -34,9 +34,9 @@
 using namespace Buteo;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-void logMessageHandler(QtMsgType aType, const QMessageLogContext&, const QString& aMsg)
+void Logger::logMessageHandler(QtMsgType aType, const QMessageLogContext&, const QString& aMsg)
 #else
-void logMessageHandler(QtMsgType aType, const char *aMsg)
+void Logger::logMessageHandler(QtMsgType aType, const char *aMsg)
 #endif
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
@@ -49,6 +49,35 @@ void logMessageHandler(QtMsgType aType, const char *aMsg)
 const int Logger::DEFAULT_INDENT_SIZE = 4;
 
 Logger *Logger::sInstance = NULL;
+
+void Logger::setLogLevelFromFile()
+{
+    if(QFile::exists(LOGGER_CONFIG_FILE)) {
+        // read the config level from the file and set
+        // that level
+        QFile file(LOGGER_CONFIG_FILE);
+        if(file.open(QIODevice::ReadOnly)) {
+            bool ok;
+            int level = file.readLine().simplified().toInt(&ok,10);
+            if(ok)
+            {
+                Buteo::Logger::createInstance(SYNC_LOG_FILE_PATH);
+                if(!Buteo::Logger::instance()->setLogLevel(level)) {
+                    qWarning() << "invalid log level" ;
+                }
+                else
+                {
+                    qDebug()  << "Setting Log Level to " << level;
+                }
+            }
+            else
+            {
+                Buteo::Logger::createInstance();
+            }
+            file.close();
+        }
+    }
+}
 
 Logger *Logger::instance()
 {

--- a/libbuteosyncfw/common/Logger.h
+++ b/libbuteosyncfw/common/Logger.h
@@ -32,7 +32,10 @@
 #include <QMutex>
 #include <QString>
 #include <QTextStream>
+#include <SyncCommonDefs.h>
 
+const QString LOGGER_CONFIG_FILE( "/etc/buteo/set_sync_log_level" );
+const QString SYNC_LOG_FILE_PATH( Sync::syncCacheDir() + QDir::separator() + "synchronizer.log");
 
 namespace Buteo {
     
@@ -131,6 +134,12 @@ public:
     QBitArray getLogLevelArray();
 
     bool enabled(){return iEnabled;}
+
+    static void setLogLevelFromFile();
+
+    static void logMessageHandler(QtMsgType aType,
+                                  const QMessageLogContext&,
+                                  const QString& aMsg);
 
 private:
     Logger(const QString &aLogFileName, bool aUseStdOut, int aIndentSize);

--- a/msyncd/main.cpp
+++ b/msyncd/main.cpp
@@ -32,38 +32,6 @@
 #include "synchronizer.h"
 #include "SyncSigHandler.h"
 
-const QString LOGGER_CONFIG_FILE( "/etc/buteo/set_sync_log_level" );
-const QString SYNC_LOG_FILE_PATH( Sync::syncCacheDir() + QDir::separator() + "synchronizer.log");
-
-void setLogLevelFromFile()
-{
-    if(QFile::exists(LOGGER_CONFIG_FILE)) {
-        // read the config level from the file and set
-        // that level
-        QFile file(LOGGER_CONFIG_FILE);
-        if(file.open(QIODevice::ReadOnly)) {
-            bool ok;
-            int level = file.readLine().simplified().toInt(&ok,10);
-            if(ok)
-            {
-                Buteo::Logger::createInstance(SYNC_LOG_FILE_PATH);
-                if(!Buteo::Logger::instance()->setLogLevel(level)) {
-                    qWarning() << "invalid log level" ;
-                }
-                else
-                {
-                    qDebug()  << "Setting Log Level to " << level;
-                }
-            }
-            else
-            {
-                Buteo::Logger::createInstance();
-            }
-            file.close();
-        }
-    }
-}
-
 Q_DECL_EXPORT int main( int argc, char* argv[] )
 {
     // remove this later on if not needed in harmattan,
@@ -77,7 +45,7 @@ Q_DECL_EXPORT int main( int argc, char* argv[] )
     QDBusConnection::sessionBus();
     QDBusConnection::systemBus();
 
-    setLogLevelFromFile();
+    Buteo::Logger::setLogLevelFromFile();
 
     LOG_DEBUG("Starting Log At :"  << QDateTime::currentDateTime()  );
 


### PR DESCRIPTION
Buteo installs its own logger because of which plugins or UI apps using
Buteo framework might not be able control their own logging. Now added
two methods in LogMacros.h LOG_RESET (to remove the install Buteo
logger) and SET_BUTEO_LOGGER(to set the Buteo logging again)

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
