### PR TITLE
Using Qt methods to log output to stdout and removed logging to file

### DIFF
--- a/libbuteosyncfw/common/LogMacros.h
+++ b/libbuteosyncfw/common/LogMacros.h
@@ -48,20 +48,30 @@
 #define LOG_TRACE(msg) LOG_MSG_L(QtDebugMsg, msg)
 #define LOG_TRACE_PLAIN(msg) LOG_MSG_L_PLAIN(QtDebugMsg, msg)
 */
+
+#ifdef WANT_TRACE
+    #define LOG_PROTOCOL(msg) qDebug() << msg
+    #define LOG_INFO(msg) qDebug() << msg
+    #define LOG_DEBUG(msg) qDebug() << __FILE__ << __LINE__ << ":" << msg
+    #define LOG_TRACE(msg) qDebug() << msg
+    #define LOG_TRACE_PLAIN(msg) qDebug() << msg
+    /*!
+     * Creates a trace message to log when the function is entered and exited.
+     * Logs also to time spent in the function.
+     */
+    #define FUNCTION_CALL_TRACE Buteo::LogTimer timerDebugVariable(QString(__PRETTY_FUNCTION__));
+#else
+    #define LOG_DEBUG(msg)
+    #define LOG_TRACE(msg)
+    #define LOG_TRACE_PLAIN(msg)
+    #define LOG_INFO(msg)
+    #define LOG_PROTOCOL(msg)
+    #define FUNCTION_CALL_TRACE
+#endif
+
 #define LOG_FATAL(msg) qFatal(msg)
 #define LOG_CRITICAL(msg) qCritical() << msg
 #define LOG_WARNING(msg) qWarning() << msg
-#define LOG_PROTOCOL(msg) qDebug() << msg
-#define LOG_INFO(msg) qDebug() << msg
-#define LOG_DEBUG(msg) qDebug() << msg
-#define LOG_TRACE(msg) qDebug() << msg
-#define LOG_TRACE_PLAIN(msg) qDebug() << msg
-
-/*!
- * Creates a trace message to log when the function is entered and exited.
- * Logs also to time spent in the function.
- */
-#define FUNCTION_CALL_TRACE Buteo::LogTimer timerDebugVariable(QString(__PRETTY_FUNCTION__));
 
 namespace Buteo {
 

--- a/libbuteosyncfw/common/LogMacros.h
+++ b/libbuteosyncfw/common/LogMacros.h
@@ -29,6 +29,7 @@
 #include <QTime>
 #include <QDebug>
 #include <QDateTime>
+#include <QtGlobal>
 #include "Logger.h"
 
 //! Helper macro for writing log messages. Avoid using directly.
@@ -37,6 +38,7 @@
 
 //! Macros for writing log messages. Use these.
 //! Messages with level below warning are enabled only in debug builds.
+/*
 #define LOG_FATAL(msg) LOG_MSG_L(QtFatalMsg, msg)
 #define LOG_CRITICAL(msg) LOG_MSG_L(QtCriticalMsg, msg)
 #define LOG_WARNING(msg) LOG_MSG_L(QtWarningMsg, msg)
@@ -45,6 +47,15 @@
 #define LOG_DEBUG(msg) LOG_MSG_L(QtDebugMsg, msg)
 #define LOG_TRACE(msg) LOG_MSG_L(QtDebugMsg, msg)
 #define LOG_TRACE_PLAIN(msg) LOG_MSG_L_PLAIN(QtDebugMsg, msg)
+*/
+#define LOG_FATAL(msg) qFatal(msg)
+#define LOG_CRITICAL(msg) qCritical() << msg
+#define LOG_WARNING(msg) qWarning() << msg
+#define LOG_PROTOCOL(msg) qDebug() << msg
+#define LOG_INFO(msg) qDebug() << msg
+#define LOG_DEBUG(msg) qDebug() << msg
+#define LOG_TRACE(msg) qDebug() << msg
+#define LOG_TRACE_PLAIN(msg) qDebug() << msg
 
 /*!
  * Creates a trace message to log when the function is entered and exited.

--- a/msyncd/main.cpp
+++ b/msyncd/main.cpp
@@ -77,7 +77,10 @@ Q_DECL_EXPORT int main( int argc, char* argv[] )
     QDBusConnection::sessionBus();
     QDBusConnection::systemBus();
 
-    setLogLevelFromFile();
+    // This could be enabled to log the output to file
+    // Disabling the output to file for now. To get the output, run msyncd from
+    // cmd-line
+    //setLogLevelFromFile();
 
     LOG_DEBUG("Starting Log At :"  << QDateTime::currentDateTime()  );
 

--- a/msyncd/msyncd.pro
+++ b/msyncd/msyncd.pro
@@ -16,6 +16,8 @@ QMAKE_PKGCONFIG_LIBDIR  = $$target.path
 QMAKE_PKGCONFIG_INCDIR  = $$headers.path
 pkgconfig.files = $${TARGET}.pc
 
+#DEFINES += WANT_TRACE
+
 DEPENDPATH += .
 INCLUDEPATH += . \
     ../ \


### PR DESCRIPTION
The Qt debug methods, qDebug(), qFatal() etc. are used to log the output
to stdout rather than to a file (using the Buteo message handler). This
choice is valid, since in production devices, it is not expected that
msyncd writes to files (which it does not in the prev. way too). In dev
environment, developers can start msyncd from cmdline and check the
output there itself, or redirect the ouput to a file. msyncd now does
not initialize the Logger::instance()

Signed-off-by: Sateesh Kavuri <sateesh.kavuri@gmail.com>