### PR TITLE
[rpm] Build with %qmake5

### DIFF
--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -95,7 +95,7 @@ Group: Development/Libraries
 
 
 %build
-qmake -qt=5 -recursive CONFIG+=usb-moded
+%qmake5 -recursive CONFIG+=usb-moded
 make
 
 


### PR DESCRIPTION
Using the macro means that debug symbols are generated in testing and release.
This will help when investigating crash reports.
