### PR TITLE
[buteo-syncfw] Add defines related to slow sync and storage configuratio...

### DIFF
--- a/libbuteosyncfw/profile/ProfileEngineDefs.h
+++ b/libbuteosyncfw/profile/ProfileEngineDefs.h
@@ -76,6 +76,7 @@ const QString KEY_HIDDEN("hidden");
 const QString KEY_PROTECTED("protected");
 const QString KEY_DESTINATION_TYPE("destinationtype");
 const QString KEY_SYNC_DIRECTION("Sync Direction");
+const QString KEY_FORCE_SLOW_SYNC("force_slow_sync");
 const QString KEY_CONFLICT_RESOLUTION_POLICY("conflictpolicy");
 const QString KEY_BT_ADDRESS("bt_address");
 const QString KEY_REMOTE_ID("remote_id");


### PR DESCRIPTION
...n

Add KEY_STORAGE_SYNC_TARGET, KEY_STORAGE_ORIGIN_ID and
KEY_FORCE_SLOW_SYNC to profile manager defines.
