### PR TITLE
[buteo-syncfw] Introduce DEFINES+=USE_KEEPALIVE

### DIFF
--- a/libbuteosyncfw/profile/SyncSchedule.cpp
+++ b/libbuteosyncfw/profile/SyncSchedule.cpp
@@ -386,9 +386,7 @@ QDateTime SyncSchedule::nextSyncTime(const QDateTime &aPrevSync) const
         nextSync = QDateTime::currentDateTime();
     }
 
-
     LOG_DEBUG("nextSync" << nextSync.toString());
-
     return nextSync;
 }
 

--- a/msyncd/BackgroundSync.h
+++ b/msyncd/BackgroundSync.h
@@ -28,7 +28,7 @@
 #include <QMap>
 #include <keepalive/backgroundactivity.h>
 
-namespace Buteo {
+class BackgroundActivity;
 
 /// \brief BackgroundSync implementation.
 ///
@@ -42,6 +42,7 @@ class BackgroundSync : public QObject
     {
         QString id;
         BackgroundActivity* backgroundActivity;
+        BackgroundActivity::Frequency frequency;
     };
 
 public:
@@ -59,20 +60,21 @@ public:
      *
      * The beat will be generated between minWaitTime and maxWaitTime seconds
      * \param aProfName Name of the profile.
+     * \param seconds Sync frequency in seconds
      * \return Success indicator.
      */
 
-    bool setBackgroundSync(const QString& aProfName);
+    bool set(const QString& aProfName, int seconds);
 
     /*! \brief Removes background sync for a profile.
      *
      * \param aProfName Name of the profile.
      */
-    void removeBackgroundSync(const QString& aProfName);
+    bool remove(const QString& aProfName);
 
     /*! \brief Removes all background syncs for all profiles.
      */
-    void removeAllBackgroundSync();
+    void removeAll();
 
 signals:
 
@@ -104,12 +106,18 @@ private:
      */
     QString getProfNameFromId(const QString activityId);
 
+    /*! \brief Returns a valid BackgroundActivity frequency
+     *
+     * \param seconds Amounth of time for the frequency
+     * \return BackgroundActivity frequency
+     */
+
+    BackgroundActivity::Frequency frequencyFromSeconds(int seconds);
+
 private:
 
     ///Map of structures waiting for background sync
     QMap<QString, BActivityStruct> iScheduledSyncs;
 };
-
-}
 
 #endif // BACKGROUNDSYNC_H

--- a/msyncd/IPHeartBeat.cpp
+++ b/msyncd/IPHeartBeat.cpp
@@ -1,0 +1,155 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+#include "IPHeartBeat.h"
+#include <QStringList>
+#include "LogMacros.h"
+
+using namespace Buteo;
+
+IPHeartBeat::IPHeartBeat(QObject* aParent)
+ :  QObject(aParent)
+{
+    FUNCTION_CALL_TRACE;
+}
+
+IPHeartBeat::~IPHeartBeat()
+{
+    FUNCTION_CALL_TRACE;
+
+    removeAllWaits();
+}
+
+void IPHeartBeat::removeAllWaits()
+{
+    FUNCTION_CALL_TRACE;
+
+    QStringList profNames;
+
+    QMapIterator<QString,BeatStruct> iter(iBeatsWaiting);
+    while (iter.hasNext()) {
+        iter.next();
+        profNames.append(iter.key());
+    }
+
+    for(int i=0; i<profNames.size(); i++) {
+        removeWait(profNames[i]);
+    }
+}
+
+void IPHeartBeat::removeWait(const QString& aProfName)
+{
+    FUNCTION_CALL_TRACE;
+
+    if(iBeatsWaiting.contains(aProfName) == false)
+        return;
+
+    BeatStruct& tmp = iBeatsWaiting[aProfName];
+
+    delete tmp.sockNotifier;
+
+    iphb_discard_wakeups(tmp.iphbHandle);
+    iphb_close(tmp.iphbHandle);
+
+    iBeatsWaiting.remove(aProfName);
+}
+
+bool IPHeartBeat::getProfNameFromFd(int aSockFd, QString& aProfName)
+{
+    FUNCTION_CALL_TRACE;
+
+    bool ret = false;
+
+    QMapIterator<QString,BeatStruct> iter(iBeatsWaiting);
+
+    while (iter.hasNext()) {
+        iter.next();
+        const BeatStruct& tmp = iter.value();
+        if(tmp.sockfd == aSockFd) {
+            aProfName = iter.key();
+            ret = true;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+bool IPHeartBeat::setHeartBeat(const QString& aProfName, ushort aMinWaitTime, ushort aMaxWaitTime)
+{
+    FUNCTION_CALL_TRACE;
+
+    if( (aMinWaitTime > aMaxWaitTime) || aProfName.isEmpty() )
+        return false;
+
+    LOG_DEBUG("setHeartBeat(), profile name = " << aProfName);
+
+    if(iBeatsWaiting.contains(aProfName) == true) {
+        LOG_DEBUG("Profile already in waiting... No new beat");
+        return true; //returing 'true' - no immediate sync request to be sent.
+    }
+
+    iphb_t iphbHandle = iphb_open(NULL);
+
+    if(iphbHandle == 0) {
+        LOG_DEBUG("iphb_open() failed.... No IP heartbeat available");
+        return false;
+    }
+
+    int sockfd = iphb_get_fd(iphbHandle);
+
+    if(sockfd < 0) {
+        LOG_DEBUG("iphb_get_fd() failed.... No IP heartbeat");
+        iphb_close(iphbHandle);
+        return false;
+    }
+
+    BeatStruct& newBeat = iBeatsWaiting[aProfName];
+    newBeat.iphbHandle = iphbHandle;
+    newBeat.sockfd = sockfd;
+    newBeat.sockNotifier = new QSocketNotifier(sockfd,QSocketNotifier::Read,0);
+
+    if(iphb_wait(iphbHandle,aMinWaitTime,aMaxWaitTime,0) == -1) {
+        LOG_DEBUG("iphb_wait() failed .... No IP heartbeat");
+        removeWait(aProfName);
+        return false;
+    }
+
+    connect(newBeat.sockNotifier,SIGNAL(activated(int)),this,SLOT(internalBeatTriggered(int)));
+
+    LOG_DEBUG("IP Heartbeat set for profile");
+
+    return true;
+}
+
+void IPHeartBeat::internalBeatTriggered(int aSockFd)
+{
+    FUNCTION_CALL_TRACE;
+
+    QString profName;
+
+    if(getProfNameFromFd(aSockFd,profName) == true) {
+        removeWait(profName);
+        LOG_DEBUG("Emitting IP  Heartbeat, profile name = " << profName);
+        emit onHeartBeat(profName);
+    }
+}

--- a/msyncd/IPHeartBeat.h
+++ b/msyncd/IPHeartBeat.h
@@ -1,0 +1,123 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+#ifndef IPHEARTBEAT_H
+#define IPHEARTBEAT_H
+
+#include <QObject>
+#include <QMap>
+#include <QSocketNotifier>
+extern "C" {
+    #include "iphbd/libiphb.h"
+}
+
+namespace Buteo {
+
+/// \brief IPHeartBeat implementation.
+///
+/// This class manages heart beats for different profiles.
+class IPHeartBeat : public QObject
+{
+    Q_OBJECT
+
+    /// \brief Internal structure to hold profile-iphb stucture-notifier map
+    struct BeatStruct
+    {
+        int sockfd;
+        QSocketNotifier* sockNotifier;
+        iphb_t iphbHandle;
+    };
+
+public:
+    /*! \brief Constructor.
+     *  \param aParent Parent object.
+     */
+    IPHeartBeat(QObject *aParent);
+
+    /**
+     * \brief Destructor
+     */
+    virtual ~IPHeartBeat();
+
+    /*! \brief Schedules a heartbeat for this profile between minWaitTime and maxWaitTime.
+     *
+     * The beat will be generated between minWaitTime and maxWaitTime seconds
+     * \param aProfName Name of the profile.
+     * \param aMinWaitTime Minimum wait time in seconds.
+     * \param aMaxWaitTime Minimum wait time in seconds.
+     * \return Success indicator.
+     */
+    bool setHeartBeat(const QString& aProfName, ushort aMinWaitTime, ushort aMaxWaitTime);
+
+    /*! \brief Removes heart beat waiting for a profile.
+     *
+     * \param aProfName Name of the profile.
+     */
+    void removeWait(const QString& aProfName);
+
+    /*! \brief Removes heart beat waiting for all profiles.
+     */
+    void removeAllWaits();
+
+signals:
+
+    /*! \brief This signal will be emitted when a heartbeat for particular profile is triggered.
+     *
+     * \param aProfName Name of the profile for which heart beat is triggered.
+     */
+    void onHeartBeat(QString aProfName);
+
+
+private slots:
+
+    /*! \brief This signal will be emitted when a socket descriptor gets an event notification.
+     *
+     * \param aSockFd Socket descriptor who got the event.
+     */
+    void internalBeatTriggered(int aSockFd);
+
+
+private:
+
+    /*! \brief Finds the name of the profile which uses particular file descriptor
+     *
+     * \param aSockFd Socket descriptor.
+     * \param aProfName name of the profile.
+     * \return true if profile name found, otherwise false
+     */
+    bool getProfNameFromFd(int aSockFd, QString& aProfName);
+
+
+private:
+
+    ///Map of structures waiting for heart beat
+    QMap<QString, BeatStruct> iBeatsWaiting;
+
+#ifdef SYNCFW_UNIT_TESTS
+    friend class IPHeartBeatTest;
+#endif
+
+};
+
+}
+
+#endif

--- a/msyncd/SyncAlarmInventory.h
+++ b/msyncd/SyncAlarmInventory.h
@@ -28,7 +28,6 @@
 #include <QObject>
 #include <QDateTime>
 #include <QtSql>
-#include <keepalive/backgroundactivity.h>
 
 /*! \brief Class for storing alarms
  *
@@ -88,9 +87,8 @@ class SyncAlarmInventory : public QObject
         /* Method to fetch the database handle */
         QSqlDatabase*  getDbHandle();
 
-        /* BackgroundActivity object to keep track of alarm timers */
-
-        BackgroundActivity *iBackgroundActivity;
+        /* Timer object to keep tracke of alarm timers */
+        QTimer*        iTimer;
 
         /* Current alarm that is under work */
         int            currentAlarm;

--- a/msyncd/SyncOnChangeScheduler.cpp
+++ b/msyncd/SyncOnChangeScheduler.cpp
@@ -72,8 +72,6 @@ SyncOnChangeTimer::~SyncOnChangeTimer()
 void SyncOnChangeTimer::fire()
 {
     FUNCTION_CALL_TRACE;
-    // If this code changes in the future to be possible to call this from background
-    // processes, QTimer needs to change to BackgroundActivity.
     QTimer::singleShot(iTimeout*1000, this, SLOT(onTimeout()));
 }
 

--- a/msyncd/msyncd.pro
+++ b/msyncd/msyncd.pro
@@ -24,7 +24,7 @@ INCLUDEPATH += . \
     ../libbuteosyncfw/profile
 
 
-PKGCONFIG += dbus-1 libiphb keepalive
+PKGCONFIG += dbus-1
 
 equals(QT_MAJOR_VERSION, 4): {
     PKGCONFIG += libsignon-qt accounts-qt
@@ -71,8 +71,7 @@ HEADERS += ServerActivator.h \
     SyncSigHandler.h \
     StorageChangeNotifier.h \
     SyncOnChange.h \
-    SyncOnChangeScheduler.h \
-    BackgroundSync.h
+    SyncOnChangeScheduler.h
 
 SOURCES += ServerActivator.cpp \
     TransportTracker.cpp \
@@ -96,8 +95,26 @@ SOURCES += ServerActivator.cpp \
     SyncSigHandler.cpp \
     StorageChangeNotifier.cpp \
     SyncOnChange.cpp \
-    SyncOnChangeScheduler.cpp \
-    BackgroundSync.cpp
+    SyncOnChangeScheduler.cpp
+
+contains(DEFINES, USE_KEEPALIVE) {
+    PKGCONFIG += keepalive
+
+    HEADERS += \
+        BackgroundSync.h
+
+    SOURCES += \
+        BackgroundSync.cpp
+
+} else {
+    PKGCONFIG += libiphb
+
+    HEADERS += \
+        IPHeartBeat.h
+
+    SOURCES += \
+        IPHeartBeat.cpp
+}
 
 QMAKE_CXXFLAGS = -Wall \
     -g \

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -109,8 +109,8 @@ bool Synchronizer::initialize()
             this, SLOT(slotSyncStatus(QString, int, QString, int)),
             Qt::QueuedConnection);
 
-    connect(&iProfileManager,SIGNAL(signalProfileChanged(QString,int,QString)),
-            this ,SIGNAL(signalProfileChanged(QString,int,QString)));
+    connect(&iProfileManager ,SIGNAL(signalProfileChanged(QString,int,QString)),
+            this, SIGNAL(signalProfileChanged(QString,int,QString)));
 
     iNetworkManager = new NetworkManager(this);
     Q_ASSERT(iNetworkManager);
@@ -1083,8 +1083,6 @@ void Synchronizer::initializeScheduler()
         iSyncScheduler = new SyncScheduler(this);
         connect(iSyncScheduler, SIGNAL(syncNow(QString)),
                 this, SLOT(startScheduledSync(QString)), Qt::QueuedConnection);
-        connect(this, SIGNAL(syncDone(QString)),
-                iSyncScheduler, SLOT(syncDone(QString)),  Qt::QueuedConnection);
         QList<SyncProfile*> profiles = iProfileManager.allSyncProfiles();
         foreach (SyncProfile *profile, profiles)
         {
@@ -1472,6 +1470,10 @@ void Synchronizer::reschedule(const QString &aProfileName)
     if(profile && profile->syncType() == SyncProfile::SYNC_SCHEDULED && profile->isEnabled())
     {
         iSyncScheduler->addProfile(profile);
+    } else {
+        LOG_DEBUG("Sync got disabled for" << aProfileName);
+        iSyncScheduler->removeProfile(aProfileName);
+
     }
     if(profile)
     {

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name: buteo-syncfw-qt5
-Version: 0.6.15
+Version: 0.6.25
 Release: 1
 Summary: Synchronization backend
 Group: System/Libraries
@@ -96,7 +96,7 @@ Group: Development/Libraries
 
 
 %build
-%qmake5 -recursive CONFIG+=usb-moded
+%qmake5 -recursive CONFIG+=usb-moded DEFINES+=USE_KEEPALIVE
 make %{_smp_mflags}
 
 

--- a/unittests/tests/msyncdtests/IPHeartBeatTest.cpp
+++ b/unittests/tests/msyncdtests/IPHeartBeatTest.cpp
@@ -1,0 +1,82 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+#include "SyncFwTestLoader.h"
+#include "IPHeartBeatTest.h"
+#include "IPHeartBeat.h"
+
+using namespace Buteo;
+
+void IPHeartBeatTest::initTestCase()
+{
+    iHbeat = new IPHeartBeat(this);
+    connect(iHbeat,SIGNAL(onHeartBeat(QString)),this,SLOT(onBeatTriggered(QString)));
+}
+
+void IPHeartBeatTest::cleanupTestCase()
+{
+    delete iHbeat;
+}
+
+void IPHeartBeatTest::testSetHeartBeat()
+{
+    iBeatReceived = false;
+    if(iHbeat->setHeartBeat("someprofile",0,2) == true) {
+        QTest::qWait(1000*3);
+        QVERIFY(iBeatReceived == true);
+    } else {
+        // If iphbd service is not running setHeartBeat() will fail
+        // Not letting that to make the test to fail
+        qDebug() << "******* Start the iphbd service and run this test *******";
+    }
+}
+
+void IPHeartBeatTest::testRemoveHeartBeat()
+{
+    iHbeat->setHeartBeat("someprofile",0,20);
+
+    iHbeat->removeWait("someprofile");
+
+    QVERIFY(iHbeat->iBeatsWaiting.contains("someprofile") == false);
+}
+
+void IPHeartBeatTest::testRemoveAllHeartBeats()
+{
+    iHbeat->setHeartBeat("someprofile",0,20);
+    iHbeat->setHeartBeat("anotherprofile",50,100);
+
+    iHbeat->removeAllWaits();
+
+    QVERIFY(iHbeat->iBeatsWaiting.size() == 0);
+}
+
+void IPHeartBeatTest::testInternalBeat()
+{
+    iHbeat->internalBeatTriggered(-1);
+}
+
+void IPHeartBeatTest::onBeatTriggered(QString /*aProfName*/)
+{
+    iBeatReceived = true;
+}
+
+TESTLOADER_ADD_TEST(IPHeartBeatTest);

--- a/unittests/tests/msyncdtests/IPHeartBeatTest.h
+++ b/unittests/tests/msyncdtests/IPHeartBeatTest.h
@@ -1,0 +1,55 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+#ifndef IPHEARTBEAT_TEST_H
+#define IPHEARTBEAT_TEST_H
+
+#include <QtTest/QtTest>
+#include <QString>
+
+namespace Buteo {
+
+class IPHeartBeat;
+
+class IPHeartBeatTest: public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void testSetHeartBeat();
+    void testRemoveHeartBeat();
+    void testRemoveAllHeartBeats();
+    void testInternalBeat();
+
+    void onBeatTriggered(QString aProfName);
+
+private:
+    IPHeartBeat* iHbeat;
+    bool iBeatReceived;
+};
+
+}
+
+#endif

--- a/unittests/tests/msyncdtests/msyncdtests.pro
+++ b/unittests/tests/msyncdtests/msyncdtests.pro
@@ -13,7 +13,7 @@ equals(QT_MAJOR_VERSION, 4): {
     MOBILITY += systeminfo
 }
 
-PKGCONFIG += dbus-1 libiphb keepalive
+PKGCONFIG += dbus-1
 
 equals(QT_MAJOR_VERSION, 5): PKGCONFIG += Qt5SystemInfo
 
@@ -25,7 +25,6 @@ SOURCES += ServerThread.cpp \
     SyncQueue.cpp \
     AccountsHelperTest.cpp \
     AccountsHelper.cpp \
-    SyncSchedulerTest.cpp \
     SyncScheduler.cpp \
     SyncSession.cpp \
     SyncSessionTest.cpp \
@@ -53,8 +52,7 @@ SOURCES += ServerThread.cpp \
     SyncSigHandlerTest.cpp \
     SyncOnChange.cpp \
     SyncOnChangeScheduler.cpp \
-    StorageChangeNotifier.cpp \
-    BackgroundSync.cpp
+    StorageChangeNotifier.cpp
 
 HEADERS += ServerThread.h \
     ServerThreadTest.h \
@@ -62,7 +60,6 @@ HEADERS += ServerThread.h \
     SyncQueueTest.h \
     AccountsHelperTest.h \
     AccountsHelper.h \
-    SyncSchedulerTest.h \
     SyncScheduler.h \
     SyncSession.h \
     SyncSessionTest.h \
@@ -92,10 +89,30 @@ HEADERS += ServerThread.h \
     SyncSigHandlerTest.h \
     SyncOnChange.h \
     SyncOnChangeScheduler.h \
-    StorageChangeNotifier.h \
-    BackgroundSync.h
+    StorageChangeNotifier.h
 
-OTHER_FILES +=
+contains(DEFINES, USE_KEEPALIVE) {
+    PKGCONFIG += keepalive
+
+    HEADERS += \
+        BackgroundSync.h
+
+    SOURCES += \
+        BackgroundSync.cpp
+
+} else {
+    PKGCONFIG += libiphb
+
+    HEADERS += \
+        SyncSchedulerTest.h \
+        IPHeartBeat.h \
+        IPHeartBeatTest.h
+
+    SOURCES += \
+        SyncSchedulerTest.cpp \
+        IPHeartBeat.cpp \
+        IPHeartBeatTest.cpp
+}
 
 # for compiling on meego
 linux-g++-maemo {


### PR DESCRIPTION
Introduce platform specific code that uses the nemo-keepalive apis.
All existent code is kept intact when this new DEFINES is not used.
This commit also reverts some of changes done by 7674c260812b8656f18e40e58f92efd2e7f8228e
