### PR TITLE
[buteo-syncfw] Emit network error if session is not open in less than 10secs

### DIFF
--- a/msyncd/NetworkManager.h
+++ b/msyncd/NetworkManager.h
@@ -102,6 +102,7 @@ signals:
             static bool                     m_isSessionActive;          // Flag to indicate if a network session is active
             bool                            m_isOnline;                 // Flag to indicate if the device is online
             static int                      m_refCount;                 // Reference counter for number of open connections
+            bool                            m_errorEmitted;             // Network error emited flag
 private slots:
             void slotOnlineStateChanged(bool isOnline);
             void slotSessionState(QNetworkSession::State status);


### PR DESCRIPTION
In some conditions Qt network layer can take some time to fail,
since msyncd runs as a background process is not desirable to wait
long for a network request reply, with this PR if no reply comes in 10secs
a network error is emitted.
