### PR TITLE
[buteo-syncfw] Don't run oneshot script in image creation mode

### DIFF
--- a/oneshot/msyncd-storage-perm
+++ b/oneshot/msyncd-storage-perm
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-storage_dir=/home/nemo/.cache/msyncd
+DEF_UID=$(grep "^UID_MIN" /etc/login.defs |  tr -s " " | cut -d " " -f2)
+DEVICEUSER=$(getent passwd $DEF_UID | sed 's/:.*//')
+if [ ! -d "/home/$DEVICEUSER/.cache" ]; then
+    exit 1
+fi
+storage_dir="/home/$DEVICEUSER/.cache/msyncd"
 mkdir -p $storage_dir
 chown privileged $storage_dir
 chgrp privileged $storage_dir


### PR DESCRIPTION
Otherwise ~/.cache is created with root ownership.
