### PR TITLE
[buteo-syncfw] Fix warning

### DIFF
--- a/libbuteosyncfw/pluginmgr/SyncPluginBase.h
+++ b/libbuteosyncfw/pluginmgr/SyncPluginBase.h
@@ -89,7 +89,7 @@ public:
 	 * (success or error) is still expected from the aborted session before
 	 * it terminates.
 	 */
-        virtual void abortSync(Sync::SyncStatus aStatus = Sync::SYNC_ABORTED) { };
+        virtual void abortSync(Sync::SyncStatus aStatus = Sync::SYNC_ABORTED) { Q_UNUSED(aStatus); };
 
 	/*! \brief Cleans up any sync related stuff (e.g sync anchors etc) when the
 	 * profile is deleted


### PR DESCRIPTION
This commit marks a parameter in an empty inline virtual function
implementation as Q_UNUSED to suppress a warning when the header is
included from a client plugin.
