### PR TITLE
[msyncd] Use 24 hours as largest BackgroundActivity frequency

### DIFF
--- a/msyncd/BackgroundSync.cpp
+++ b/msyncd/BackgroundSync.cpp
@@ -190,5 +190,5 @@ BackgroundActivity::Frequency BackgroundSync::frequencyFromSeconds(int seconds) 
     else if (minutes <= 12 * 60)
         return BackgroundActivity::TwelveHours;
     else
-        return BackgroundActivity::MaximumFrequency; //18h
+        return BackgroundActivity::TwentyFourHours;
 }


### PR DESCRIPTION
Previously, the fallback was the MaximumFrequency value, but this
value is not useful for synchronization schedules.
