### PR TITLE
[buteo-syncfw] Don't allow plugins using the same client plugin to run at the same time.

### DIFF
--- a/msyncd/SyncQueue.cpp
+++ b/msyncd/SyncQueue.cpp
@@ -86,6 +86,13 @@ bool SyncQueue::isEmpty() const
     return iItems.isEmpty();
 }
 
+int SyncQueue::size() const
+{
+    FUNCTION_CALL_TRACE;
+
+    return iItems.size();
+}
+
 bool SyncQueue::contains(const QString &aProfileName) const
 {
     FUNCTION_CALL_TRACE;

--- a/msyncd/SyncQueue.h
+++ b/msyncd/SyncQueue.h
@@ -67,6 +67,12 @@ public:
      */
     bool isEmpty() const;
 
+    /*! \brief Current size of the sync queue.
+     *
+     * \return Number of elements in the sync queue.
+     */
+    int size() const;
+
     /*! \brief Checks if a profile with the given name is in the queue.
      *
      * \return Is the profile in the queue.

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -355,6 +355,8 @@ private:
      */
     bool cleanupProfile(const QString &profileId);
 
+    bool clientProfileActive(const QString &clientProfileName);
+
     QMap<QString, SyncSession*> iActiveSessions;
 
     QList<QString> iProfilesToRemove;


### PR DESCRIPTION
Don't try to reuse processes for OOP client plugins.
