### PR TITLE
[buteo-syncfw] Don't emit network error if session is open.

### DIFF
--- a/libbuteosyncfw/common/NetworkManager.cpp
+++ b/libbuteosyncfw/common/NetworkManager.cpp
@@ -116,8 +116,10 @@ void NetworkManager::connectSession(bool connectInBackground /* = false*/)
 void NetworkManager::sessionConnectionTimeout()
 {
     if (!m_errorEmitted && m_networkSession) {
-        qWarning() << "No network reply received after 10 seconds, emitting session error.";
-        slotSessionError(m_networkSession->error());
+        if (!m_networkSession->isOpen()) {
+            qWarning() << "No network reply received after 10 seconds, emitting session error.";
+            slotSessionError(m_networkSession->error());
+        }
     }
 }
 


### PR DESCRIPTION
This can happen in some race condition cases.
