### PR TITLE
[buteo-syncfw] Make logging configurable at runtime with MSYNCD_LOGGING_...

### DIFF
--- a/libbuteosyncfw/common/LogMacros.h
+++ b/libbuteosyncfw/common/LogMacros.h
@@ -41,25 +41,18 @@
 #define LOG_CRITICAL(msg) qCritical() << msg
 #define LOG_WARNING(msg) qWarning() << msg
 
-#if defined(BUTEO_ENABLE_DEBUG)
-# define LOG_PROTOCOL(msg) qDebug() << msg
-# define LOG_INFO(msg) qDebug() << msg
-# define LOG_DEBUG(msg) qDebug() << msg
-# define LOG_TRACE(msg) qDebug() << msg
-# define LOG_TRACE_PLAIN(msg) qDebug() << msg
+// use relevant logging level numbers from syslog.h where possible
+# define LOG_PROTOCOL(msg) if (Buteo::Logger::instance()->getLogLevel() >= 6) qDebug() << msg
+# define LOG_INFO(msg) if (Buteo::Logger::instance()->getLogLevel() >= 6) qDebug() << msg
+# define LOG_DEBUG(msg) if (Buteo::Logger::instance()->getLogLevel() >= 7) qDebug() << msg
+# define LOG_TRACE(msg) if (Buteo::Logger::instance()->getLogLevel() >= 8) qDebug() << msg
+# define LOG_TRACE_PLAIN(msg) if (Buteo::Logger::instance()->getLogLevel() >= 8) qDebug() << msg
+
  /*!
   * Creates a trace message to log when the function is entered and exited.
   * Logs also to time spent in the function.
   */
-# define FUNCTION_CALL_TRACE Buteo::LogTimer timerDebugVariable(QString(__PRETTY_FUNCTION__));
-#else
-# define LOG_PROTOCOL(msg) if (false) qDebug() << msg
-# define LOG_INFO(msg) if (false) qDebug() << msg
-# define LOG_DEBUG(msg) if (false) qDebug() << msg
-# define LOG_TRACE(msg) if (false) qDebug() << msg
-# define LOG_TRACE_PLAIN(msg) if (false) qDebug() << msg
-# define FUNCTION_CALL_TRACE
-#endif
+# define FUNCTION_CALL_TRACE if (Buteo::Logger::instance()->getLogLevel() >= 9) Buteo::LogTimer timerDebugVariable(QString(__PRETTY_FUNCTION__));
 
 namespace Buteo {
 

--- a/libbuteosyncfw/common/Logger.h
+++ b/libbuteosyncfw/common/Logger.h
@@ -130,10 +130,17 @@ public:
      */
     QBitArray getLogLevelArray();
 
+    /*!
+     * \brief Gets the logging level as a single number.
+     */
+    int getLogLevel() const;
+
     bool enabled(){return iEnabled;}
 
 private:
     Logger(const QString &aLogFileName, bool aUseStdOut, int aIndentSize);
+
+    static int defaultLogLevel();
 
     static Logger *sInstance;
 
@@ -154,6 +161,8 @@ private:
     QMutex      iMutex;
 
     bool        iEnabled;
+
+    int         iLogLevel;
 };
 
 }

--- a/msyncd/main.cpp
+++ b/msyncd/main.cpp
@@ -45,10 +45,8 @@ Q_DECL_EXPORT int main( int argc, char* argv[] )
     QDBusConnection::sessionBus();
     QDBusConnection::systemBus();
 
-    // This could be enabled to log the output to file
-    // Disabling the output to file for now. To get the output, run msyncd from
-    // cmd-line
-    //setLogLevelFromFile();
+    // Initialize the logger
+    Buteo::Logger::instance();
 
     LOG_DEBUG("Starting Log At :"  << QDateTime::currentDateTime()  );
 


### PR DESCRIPTION
...LEVEL

Read the default logging level from a MSYNCD_LOGGING_LEVEL
environment variable. If it is not set, the level defaults to 4
(warning level).

Also remove the logging code that installs custom message handlers
as this doesn't play well with other processes that are logging.
