### PR TITLE
[buteo-syncfw] Export Logger symbols

### DIFF
--- a/libbuteosyncfw/common/Logger.h
+++ b/libbuteosyncfw/common/Logger.h
@@ -45,7 +45,7 @@ namespace Buteo {
  * or by simply logging some message, which will automatically create the
  * logger instance with default parameters.
  */
-class Logger
+class Q_DECL_EXPORT Logger
 {
 public:
     


### PR DESCRIPTION
Now that the Logger uses runtime log level detection, the LOG_INFO
etc macros call Logger implementation, which must be exported so
that external clients using the logging macros continue to work.
