### PR TITLE
[buteo-syncfw] Introduce external sync settings.

### DIFF
--- a/libbuteosyncfw/profile/ProfileEngineDefs.h
+++ b/libbuteosyncfw/profile/ProfileEngineDefs.h
@@ -47,6 +47,7 @@ const QString ATTR_MAJOR_CODE("majorcode");
 const QString ATTR_MINOR_CODE("minorcode");
 const QString ATTR_ENABLED("enabled");
 const QString ATTR_SYNC_CONFIGURE("syncconfiguredtime");
+const QString ATTR_EXTERNAL_SYNC("externalsync");
 
 const QString TAG_FIELD("field");
 const QString TAG_PROFILE("profile");

--- a/libbuteosyncfw/profile/SyncSchedule.h
+++ b/libbuteosyncfw/profile/SyncSchedule.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -37,8 +38,10 @@ class SyncScheduleTest;
 typedef QSet<int> DaySet;
 
 const QString SYNC_SCHEDULE_ENABLED_KEY_BOOL("scheduler/schedule_enabled");
+const QString SYNC_EXTERNAL_SCHEDULE_ENABLED_KEY_BOOL("scheduler/external_schedule_enabled");
 const QString SYNC_SCHEDULE_PEAK_ENABLED_KEY_BOOL("scheduler/schedule_peak_enabled");
 const QString SYNC_SCHEDULE_OFFPEAK_ENABLED_KEY_BOOL("scheduler/schedule_offpeak_enabled");
+const QString SYNC_SCHEDULE_EXTERNAL_PEAK_ENABLED_KEY_BOOL("scheduler/schedule_external_peak_enabled");
 const QString SYNC_SCHEDULE_PEAK_DAYS_KEY_INT ("scheduler/schedule_peak_days");
 const QString SYNC_SCHEDULE_PEAK_START_TIME_KEY_INT ("scheduler/schedule_peak_start_time");
 const QString SYNC_SCHEDULE_PEAK_END_TIME_KEY_INT ("scheduler/schedule_peak_end_time");
@@ -158,9 +161,22 @@ public:
 
     /*! \brief Sets if normal schedule is to be obeyed.
      *
-     * \param aEnabled Specify ifnormal scheduling hours enabled. If set to false, corresponds to "manual" mode.
+     * \param aEnabled Specify if normal scheduling hours enabled. If set to false, corresponds to "manual" mode.
      */
     void setScheduleEnabled(bool aEnabled);
+
+    /*! \brief Checks if schedule is controlled by a external process (e.g always-up-to-date).
+     *
+     * \return True if schedule is controlled by a external process. External process will control the sync,
+     * buteo schedule is disabled in this case.
+     */
+    bool externalScheduleEnabled() const;
+
+    /*! \brief Sets if schedule is controlled by a external process.
+     *
+     * \param aEnabled Specify if schedule is contolled by a external process. If set to true, buteo schedule will be set to disabled.
+     */
+    void setExternalScheduleEnabled(bool aEnabled);
 
 
     // ============== RUSH HOUR SETTINGS ============================
@@ -177,6 +193,21 @@ public:
      * \param aEnabled If set to false, corresponds to rush hour scheduling off, i.e. "manual" sync.
      */
     void setRushEnabled(bool aEnabled);
+
+    /*! \brief Checks if external rush schedule is to be obeyed.
+     *
+     * \return True if rush hour schedule is to be used by a external process, The external process will control the sync, buteo will just call
+     * the corresponding plugins when a switch from rush to offRush or vice-versa is necessary, corresponding plugins should be prepared to do any needed
+     * changes.
+     * False, if rush hour scheduling is controlled by this process or if rush hour scheduling is off (i.e. manual mode).
+     */
+    bool externalRushEnabled() const;
+
+    /*! \brief Sets external rush schedule is to be obeyed.
+     *
+     * \param aEnabled If set to true, corresponds to external rush hour scheduling on, i.e. sync controlled by a external process.
+     */
+    void setExternalRushEnabled(bool aEnabled);
 
     /*! \brief Gets days enabled for rush hours.
      *

--- a/libbuteosyncfw/profile/SyncSchedule_p.h
+++ b/libbuteosyncfw/profile/SyncSchedule_p.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -89,6 +90,7 @@ public:
     unsigned iInterval;
 
     bool iEnabled;
+    bool iExternalEnabled;
 
     // ============ RUSH HOUR SETTINGS =========== 
 
@@ -106,6 +108,9 @@ public:
 
     //! Indicates if Rush Hour is Enabled
     bool iRushEnabled;
+
+    //! Indicates if External Rush Hour schedule is Enabled
+    bool iExternalRushEnabled;
 };
 
 }


### PR DESCRIPTION
This commit introduces settings to the scheduler that allow a external
process to take over the sync completely or to take over the sync while on
the rush period, this can be useful in case like always-up-to-date syncs.
