### PR TITLE
[Buteo-syncfw] Don't use global static systemBus instance.

### DIFF
--- a/libbuteosyncfw/common/TransportTracker.h
+++ b/libbuteosyncfw/common/TransportTracker.h
@@ -29,6 +29,7 @@
 #include <QMap>
 #include <QMutex>
 #include <QDBusVariant>
+#include <QDBusConnection>
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include <QtSystemInfo/QSystemDeviceInfo>
 #endif
@@ -111,6 +112,7 @@ private:
 #endif
 
     NetworkManager *iInternet;
+    QDBusConnection *iSystemBus;
 
     mutable QMutex iMutex;
 


### PR DESCRIPTION
Global static destruction order cannot be controlled and we need our bus
to disconnect from the signals, so we use our own bus instance to avoid
crashes on exit.
