### PR TITLE
[buteo-syncfw] Fix memory leaks

### DIFF
--- a/libbuteosyncfw/pluginmgr/OOPClientPlugin.h
+++ b/libbuteosyncfw/pluginmgr/OOPClientPlugin.h
@@ -29,6 +29,8 @@ namespace Buteo {
 
 class OOPClientPlugin : public ClientPlugin
 {
+    Q_OBJECT
+
 public:
     OOPClientPlugin( const QString& aPluginName,
                      const Buteo::SyncProfile& aProfile,
@@ -53,6 +55,17 @@ public slots:
 
     virtual void connectivityStateChanged(Sync::ConnectivityType aType,
                                           bool aState);
+
+    void onProcessError(QProcess::ProcessError error);
+
+    void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    void onError(QString aProfileName, QString aMessage, int aErrorCode);
+
+    void onSuccess(QString aProfileName, QString aMessage);
+
+private:
+    bool iDone;
 };
 
 }

--- a/libbuteosyncfw/pluginmgr/OOPServerPlugin.h
+++ b/libbuteosyncfw/pluginmgr/OOPServerPlugin.h
@@ -28,6 +28,8 @@
 namespace Buteo {
 class OOPServerPlugin : public ServerPlugin
 {
+    Q_OBJECT
+
 public:
     OOPServerPlugin( const QString& aPluginName,
                      const Profile& aProfile,
@@ -54,6 +56,16 @@ public slots:
 
     virtual void connectivityStateChanged( Sync::ConnectivityType aType,
                                            bool aState );
+    void onProcessError(QProcess::ProcessError error);
+
+    void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    void onError(QString aProfileName, QString aMessage, int aErrorCode);
+
+    void onSuccess(QString aProfileName, QString aMessage);
+
+private:
+    bool iDone;
 };
 
 }

--- a/libbuteosyncfw/pluginmgr/PluginManager.cpp
+++ b/libbuteosyncfw/pluginmgr/PluginManager.cpp
@@ -340,6 +340,7 @@ void PluginManager::destroyClient( ClientPlugin *aPlugin )
         LOG_DEBUG( "Stopping the OOP process for " << pluginName);
         QString path = iOopClientMaps.value( pluginName );
         stopOOPPlugin( path );
+        delete aPlugin;
     }
 }
 
@@ -454,6 +455,7 @@ void PluginManager::destroyServer( ServerPlugin *aPlugin )
         // Stop the OOP server process
         QString path = iOoPServerMaps.value( pluginName );
         stopOOPPlugin( path );
+        delete aPlugin;
     }
 }
 

--- a/libbuteosyncfw/pluginmgr/SyncPluginBase.h
+++ b/libbuteosyncfw/pluginmgr/SyncPluginBase.h
@@ -155,10 +155,6 @@ signals:
 	 */
 	void syncProgressDetail( const QString &aProfileName, int aProgressDetail);
 
-    void processError( QProcess::ProcessError error );
-
-    void processFinished( int exitCode, QProcess::ExitStatus exitStatus );
-
 public slots:
 
 	/*! \brief Slot that is invoked by sync framework when changes occur in

--- a/msyncd/ClientPluginRunner.cpp
+++ b/msyncd/ClientPluginRunner.cpp
@@ -245,25 +245,6 @@ void ClientPluginRunner::onThreadExit()
     emit done();
 }
 
-void ClientPluginRunner::onProcessError( QProcess::ProcessError error )
-{
-    onError( iProfile->name(),
-             "Plugin process error:" + QString::number(error),
-             Sync::SYNC_PLUGIN_ERROR );
-}
-
-void ClientPluginRunner::onProcessFinished( int exitCode, QProcess::ExitStatus exitStatus )
-{
-    if( (exitCode != 0) ||
-        (exitStatus != QProcess::NormalExit) ) {
-    	onError( iProfile->name(),
-             	"Plugin process exited with error code " +
-                 QString::number(exitCode) + " and status " +
-                 QString::number(exitStatus),
-             	Sync::SYNC_PLUGIN_ERROR );
-    }
-}
-
 void ClientPluginRunner::pluginTimeout()
 {
     FUNCTION_CALL_TRACE;

--- a/msyncd/ClientPluginRunner.h
+++ b/msyncd/ClientPluginRunner.h
@@ -98,10 +98,6 @@ private slots:
     // Slot for observing thread exit
     void onThreadExit();
 
-    void onProcessError( QProcess::ProcessError error );
-
-    void onProcessFinished( int exitCode, QProcess::ExitStatus exitStatus );
-
     void pluginTimeout();
 
 private:

--- a/msyncd/ServerPluginRunner.cpp
+++ b/msyncd/ServerPluginRunner.cpp
@@ -289,22 +289,3 @@ void ServerPluginRunner::onSessionDone()
     }
 #endif
 }
-
-void ServerPluginRunner::onProcessError( QProcess::ProcessError error )
-{
-    onError( iProfile->name(),
-             "Plugin process error:" + QString::number(error),
-             Sync::SYNC_PLUGIN_ERROR );
-}
-
-void ServerPluginRunner::onProcessFinished( int exitCode, QProcess::ExitStatus exitStatus )
-{
-    if( (exitCode != 0) ||
-        (exitStatus != QProcess::NormalExit) ) {
-    	onError( iProfile->name(),
-             	"Plugin process exited with error code " +
-                 QString::number(exitCode) + " and exit status " +
-                 QString::number(exitStatus),
-             	Sync::SYNC_PLUGIN_ERROR );
-    }
-}

--- a/msyncd/ServerPluginRunner.h
+++ b/msyncd/ServerPluginRunner.h
@@ -105,10 +105,6 @@ private slots:
     // Slot for observing thread exit
     void onThreadExit();
 
-    void onProcessError( QProcess::ProcessError error );
-
-    void onProcessFinished( int exitCode, QProcess::ExitStatus exitStatus );
-
 private:
 
     void onSessionDone();


### PR DESCRIPTION
OOP plugins must emit either success or error signal when they are done. Not doing so results in memory leaks.

It appears that OOP plugin objects themselves have to be explicitly deallocated. Not doing so results in memory leaks too.

Removed OOP-specific methods from the generic SyncPluginBase interface.
