### PR TITLE
[libbuteosyncfw] SyncProfile : Initialize syncStatus correctly

### DIFF
--- a/libbuteosyncfw/profile/SyncProfile.cpp
+++ b/libbuteosyncfw/profile/SyncProfile.cpp
@@ -687,7 +687,7 @@ SyncProfile::CurrentSyncStatus SyncProfile::currentSyncStatus() const
 {
     //Fetch the last sync result
     const SyncResults *syncResult = lastResults();
-    SyncProfile::CurrentSyncStatus syncStatus;
+    SyncProfile::CurrentSyncStatus syncStatus = SyncProfile::SYNC_NEVER_HAPPENED;
 
     if (syncResult)
     {
@@ -698,8 +698,7 @@ SyncProfile::CurrentSyncStatus SyncProfile::currentSyncStatus() const
             syncStatus = SyncProfile::SYNC_FAILED;
         else if (syncResult->majorCode() == SyncResults::SYNC_RESULT_CANCELLED)
             syncStatus = SyncProfile::SYNC_CANCLLED;
-    } else
-        syncStatus = SyncProfile::SYNC_NEVER_HAPPENED;
+    }
 
     return syncStatus;
 }


### PR DESCRIPTION
Initialize syncStatus as there is a remote possibility it is not
correctly set. Also saves us an else ;)

Fixes: CID#58911

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
