### PR TITLE
[buteo-syncfw] Stop existing background activity before updating it

### DIFF
--- a/msyncd/BackgroundSync.cpp
+++ b/msyncd/BackgroundSync.cpp
@@ -97,6 +97,7 @@ bool BackgroundSync::set(const QString &aProfName, int seconds)
             BackgroundActivity::Frequency frequency = frequencyFromSeconds(seconds);
 
             if (newAct.frequency != frequency) {
+                newAct.backgroundActivity->stop();
                 newAct.frequency = frequency;
                 newAct.backgroundActivity->setWakeupFrequency(newAct.frequency);
                 newAct.backgroundActivity->wait();


### PR DESCRIPTION
BackgroundSync::set updates wakeup frequency for existing
background activity and calls its wait() method. If activity's state
was already Waiting, the state doesn't change, nothing happens and
the existing background activity keeps running until the previously
set time expires.
This patch stops the existing background activity first.
