### PR TITLE
[buteo-syncfw] Remove scheduled sync times when profile is disabled.

### DIFF
--- a/msyncd/AccountsHelper.h
+++ b/msyncd/AccountsHelper.h
@@ -100,6 +100,7 @@ Q_SIGNALS:
     void enableSOC(const QString& aProfileName);
     void scheduleUpdated(const QString& aProfileName);
     void removeProfile(QString profileId);
+    void removeScheduledSync(const QString& profileId);
 
 private:
 

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -141,6 +141,9 @@ bool Synchronizer::initialize()
     connect(iAccounts, SIGNAL(removeProfile(QString)),
             this, SLOT(removeProfile(QString)),
             Qt::QueuedConnection);
+    connect(iAccounts, SIGNAL(removeScheduledSync(QString)),
+            this, SLOT(removeScheduledSync(QString)),
+            Qt::QueuedConnection);
     connect(this, SIGNAL(storageReleased()),
             this, SLOT(onStorageReleased()), Qt::QueuedConnection);
 
@@ -1559,6 +1562,22 @@ void Synchronizer::slotSyncStatus(QString aProfileName, int aStatus, QString /*a
             }
         }
         delete profile;
+    }
+}
+
+void Synchronizer::removeScheduledSync(const QString &aProfileName)
+{
+    FUNCTION_CALL_TRACE;
+
+    if (iSyncScheduler == 0)
+        return;
+
+    SyncProfile *profile = iProfileManager.syncProfile(aProfileName);
+
+    if(profile && !profile->isEnabled())
+    {
+        LOG_DEBUG("Sync got disabled for" << aProfileName);
+        iSyncScheduler->removeProfile(aProfileName);
     }
 }
 

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -287,6 +287,13 @@ private slots:
      */
     void slotSyncStatus(QString aProfileName, int aStatus,
                         QString aMessage, int aMoreDetails);
+
+    /*! \brief Handles the removed scheduled sync signal
+     *
+     * @param aProfileName Name of the profile
+     */
+    void removeScheduledSync(const QString &aProfileName);
+
 private:
 
     bool startSync(const QString &aProfileName, bool aScheduled);

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name: buteo-syncfw-qt5
-Version: 0.7.12
+Version: 0.7.13
 Release: 1
 Summary: Synchronization backend
 Group: System/Libraries


### PR DESCRIPTION
Make sure profiles from disabled accounts do not get enabled.
