### PR TITLE
[msyncd] Update to libaccounts-qt version 1.13

### DIFF
--- a/msyncd/AccountsHelper.cpp
+++ b/msyncd/AccountsHelper.cpp
@@ -100,7 +100,6 @@ void AccountsHelper::slotAccountCreated(Accounts::AccountId id)
                 delete syncProfile;
             }
         }
-        delete newAccount;
     }
 }
 
@@ -265,7 +264,6 @@ void AccountsHelper::setSyncSchedule(SyncProfile *syncProfile, Accounts::Account
         syncSchedule.setRushDays(rdays);
         syncSchedule.setDays(days);
         syncProfile->setSyncSchedule (syncSchedule);
-        delete account;
     }
 }
 
@@ -413,7 +411,6 @@ void AccountsHelper::addSetting(Accounts::AccountId id, QString key, QVariant va
         if (!success) {
             LOG_WARNING("Could not save settings to Account : Reason = " << iAccountManager->lastError().message());
         }
-        delete account;
     }
 }
 

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -12,7 +12,7 @@ BuildRequires: pkgconfig(Qt5DBus)
 BuildRequires: pkgconfig(Qt5Sql)
 BuildRequires: pkgconfig(Qt5Test)
 BuildRequires: pkgconfig(dbus-1)
-BuildRequires: pkgconfig(accounts-qt5)
+BuildRequires: pkgconfig(accounts-qt5) >= 1.13
 BuildRequires: pkgconfig(libsignon-qt5)
 BuildRequires: pkgconfig(Qt5SystemInfo)
 BuildRequires: pkgconfig(libiphb)


### PR DESCRIPTION
This commit ensures that we don't manually delete any account
instance which we load via Accounts::Manager::account() function
as that was made unsafe by a change between version 1.6 and 1.7
of libaccounts-qt.