### PR TITLE
[buteo-syncfw] Adapt Buteo to always-up-to-date schedule syncs.

### DIFF
--- a/libbuteosyncfw/profile/ProfileEngineDefs.h
+++ b/libbuteosyncfw/profile/ProfileEngineDefs.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -90,6 +91,7 @@ const QString KEY_LOAD_WITHOUT_TRANSPORT("load_without_transport");
 const QString KEY_CAPS_MODIFIED("caps_modified");
 const QString KEY_SYNC_SINCE_DAYS_PAST("sync_since_days_past"); // sync from this many days before the current date
 const QString KEY_SYNC_ALWAYS_UP_TO_DATE("sync_always_up_to_date");
+const QString KEY_SYNC_EXTERNALLY("sync_externally");
 const QString KEY_SOC("sync_on_change");
 const QString KEY_SOC_AFTER("sync_on_change_after");
 const QString KEY_LOCAL_URI("Local URI");

--- a/libbuteosyncfw/profile/SyncProfile.cpp
+++ b/libbuteosyncfw/profile/SyncProfile.cpp
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -218,9 +219,25 @@ void SyncProfile::setName(const QStringList &aKeys)
     d_ptr->iLog->setProfileName(Profile::name());
 }
 
+bool SyncProfile::syncExternallyEnabled() const
+{
+    return boolKey(KEY_SYNC_EXTERNALLY, false);
+}
+
 bool SyncProfile::rushEnabled() const
 {
     return d_ptr->iSchedule.rushEnabled() && d_ptr->iSchedule.scheduleEnabled();
+}
+
+bool SyncProfile::syncExternallyDuringRush() const
+{
+    return d_ptr->iSchedule.scheduleEnabled() && d_ptr->iSchedule.rushEnabled()
+            && d_ptr->iSchedule.syncExternallyDuringRush();
+}
+
+bool SyncProfile::inExternalSyncRushPeriod(QDateTime aDateTime) const
+{
+    return d_ptr->iSchedule.inExternalSyncRushPeriod(aDateTime);
 }
 
 QDateTime SyncProfile::lastSyncTime() const
@@ -318,7 +335,7 @@ void SyncProfile::addResults(const SyncResults &aResults)
 SyncProfile::SyncType SyncProfile::syncType() const
 {
     // Sync schedule is enabled for peak or manual -> it is scheduled type.
-    return (d_ptr->iSchedule.scheduleEnabled() || d_ptr->iSchedule.rushEnabled()) ? SYNC_SCHEDULED : SYNC_MANUAL;;
+    return !syncExternallyEnabled() && (d_ptr->iSchedule.scheduleEnabled() || d_ptr->iSchedule.rushEnabled()) ? SYNC_SCHEDULED : SYNC_MANUAL;
 }
 
 // TODO: seems effectless since d6d974e (Added functions to enable/disable normal scheduling.)

--- a/libbuteosyncfw/profile/SyncProfile.h
+++ b/libbuteosyncfw/profile/SyncProfile.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -155,11 +156,33 @@ public:
     //! \see Profile::toXml
     virtual QDomElement toXml(QDomDocument &aDoc, bool aLocalOnly = true) const;
 
+    /*! \brief Checks if schedule is controlled by a external process (e.g always-up-to-date).
+     *
+     * \return True if schedule is controlled by a external process. External process will control the sync,
+     * buteo schedule is disabled in this case.
+     */
+    virtual bool syncExternallyEnabled() const;
+
     /*! \brief Checks if rush/off-rush schedule is enabled.
      *
      * \return True if rush/off-rush schedule is enabled. False, if rush/off-rush scheduling is off.
      */
     virtual bool rushEnabled() const;
+
+    /*! \brief Checks if external rush schedule is to be obeyed.
+     *
+     * \return True if rush hour schedule is to be used by a external process, The external process will control the sync, buteo will just call
+     * the corresponding plugins when a switch from rush to offRush or vice-versa is necessary, corresponding plugins should be prepared to do any needed
+     * changes.
+     * False, if rush hour scheduling is controlled by this process or if rush hour scheduling is off (i.e. manual mode).
+     */
+    virtual bool syncExternallyDuringRush() const;
+
+    /*! \brief Checks if a given time is inside rush hour and if the sync is controlled by a external process.
+     *
+     * \param aDateTime DateTime to check, current DateTime used by default.
+     */
+    virtual bool inExternalSyncRushPeriod(QDateTime aDateTime = QDateTime::currentDateTime()) const;
 
     /*! \brief Gets the time of last completed sync session with this profile.
      *

--- a/libbuteosyncfw/profile/SyncSchedule.h
+++ b/libbuteosyncfw/profile/SyncSchedule.h
@@ -2,7 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2014 Jolla Ltd
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -38,10 +38,8 @@ class SyncScheduleTest;
 typedef QSet<int> DaySet;
 
 const QString SYNC_SCHEDULE_ENABLED_KEY_BOOL("scheduler/schedule_enabled");
-const QString SYNC_EXTERNAL_SCHEDULE_ENABLED_KEY_BOOL("scheduler/external_schedule_enabled");
 const QString SYNC_SCHEDULE_PEAK_ENABLED_KEY_BOOL("scheduler/schedule_peak_enabled");
 const QString SYNC_SCHEDULE_OFFPEAK_ENABLED_KEY_BOOL("scheduler/schedule_offpeak_enabled");
-const QString SYNC_SCHEDULE_EXTERNAL_PEAK_ENABLED_KEY_BOOL("scheduler/schedule_external_peak_enabled");
 const QString SYNC_SCHEDULE_PEAK_DAYS_KEY_INT ("scheduler/schedule_peak_days");
 const QString SYNC_SCHEDULE_PEAK_START_TIME_KEY_INT ("scheduler/schedule_peak_start_time");
 const QString SYNC_SCHEDULE_PEAK_END_TIME_KEY_INT ("scheduler/schedule_peak_end_time");
@@ -165,20 +163,6 @@ public:
      */
     void setScheduleEnabled(bool aEnabled);
 
-    /*! \brief Checks if schedule is controlled by a external process (e.g always-up-to-date).
-     *
-     * \return True if schedule is controlled by a external process. External process will control the sync,
-     * buteo schedule is disabled in this case.
-     */
-    bool externalScheduleEnabled() const;
-
-    /*! \brief Sets if schedule is controlled by a external process.
-     *
-     * \param aEnabled Specify if schedule is contolled by a external process. If set to true, buteo schedule will be set to disabled.
-     */
-    void setExternalScheduleEnabled(bool aEnabled);
-
-
     // ============== RUSH HOUR SETTINGS ============================
 
 
@@ -194,20 +178,19 @@ public:
      */
     void setRushEnabled(bool aEnabled);
 
-    /*! \brief Checks if external rush schedule is to be obeyed.
+    /*! \brief Checks if rush schedule is controlled by a external process.
      *
-     * \return True if rush hour schedule is to be used by a external process, The external process will control the sync, buteo will just call
-     * the corresponding plugins when a switch from rush to offRush or vice-versa is necessary, corresponding plugins should be prepared to do any needed
-     * changes.
+     * \return True if rush hour schedule is to be used by a external process, The external process will control the sync, buteo will just
+     * controll the schedule outside rush hours and will be responsible to switch from rush to no-rush(and vice-versa) modes.
      * False, if rush hour scheduling is controlled by this process or if rush hour scheduling is off (i.e. manual mode).
      */
-    bool externalRushEnabled() const;
+    bool syncExternallyDuringRush() const;
 
-    /*! \brief Sets external rush schedule is to be obeyed.
+    /*! \brief Sets if rush schedule is controlled by a external process.
      *
      * \param aEnabled If set to true, corresponds to external rush hour scheduling on, i.e. sync controlled by a external process.
      */
-    void setExternalRushEnabled(bool aEnabled);
+    void setSyncExternallyDuringRush(bool aEnabled);
 
     /*! \brief Gets days enabled for rush hours.
      *
@@ -251,6 +234,12 @@ public:
      * \param aInterval Interval.
      */
     void setRushInterval(unsigned aInterval);
+
+    /*! \brief Checks if a given time is inside rush hour and if the sync is controlled by a external process.
+     *
+     * \param aDateTime DateTime to check.
+     */
+    bool inExternalSyncRushPeriod(const QDateTime &aDateTime) const;
 
     /*! \brief Gets next sync time based on the sync schedule settings.
      *

--- a/libbuteosyncfw/profile/SyncSchedule_p.h
+++ b/libbuteosyncfw/profile/SyncSchedule_p.h
@@ -2,7 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2014 Jolla Ltd
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -90,7 +90,6 @@ public:
     unsigned iInterval;
 
     bool iEnabled;
-    bool iExternalEnabled;
 
     // ============ RUSH HOUR SETTINGS =========== 
 

--- a/msyncd/SyncDBusAdaptor.cpp
+++ b/msyncd/SyncDBusAdaptor.cpp
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -197,5 +198,11 @@ bool SyncDBusAdaptor::updateProfile(const QString &aProfileAsXml)
     bool out0;
     QMetaObject::invokeMethod(parent(), "updateProfile", Q_RETURN_ARG(bool, out0), Q_ARG(QString, aProfileAsXml));
     return out0;
+}
+
+void SyncDBusAdaptor::isSyncedExternally(uint aAccountId, const QString aClientProfileName)
+{
+    // handle method call com.meego.msyncd.isSyncedExternally
+    QMetaObject::invokeMethod(parent(), "isSyncedExternally", Q_ARG(uint, aAccountId), Q_ARG(QString, aClientProfileName));
 }
 

--- a/msyncd/SyncDBusAdaptor.h
+++ b/msyncd/SyncDBusAdaptor.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -74,6 +75,11 @@ class SyncDBusAdaptor: public QDBusAbstractAdaptor
 "      <arg direction=\"out\" type=\"i\" name=\"aFailedReason\"/>\n"
 "      <arg direction=\"out\" type=\"x\" name=\"aPrevSyncTime\"/>\n"
 "      <arg direction=\"out\" type=\"x\" name=\"aNextSyncTime\"/>\n"
+"    </signal>\n"
+"    <signal name=\"syncedExternallyStatus\">\n"
+"      <arg direction=\"out\" type=\"u\" name=\"AccountId\"/>\n"
+"      <arg direction=\"out\" type=\"s\" name=\"aClientProfileName\"/>\n"
+"      <arg direction=\"out\" type=\"b\" name=\"aState\"/>\n"
 "    </signal>\n"
 "    <method name=\"startSync\">\n"
 "      <arg direction=\"out\" type=\"b\"/>\n"
@@ -158,6 +164,11 @@ class SyncDBusAdaptor: public QDBusAbstractAdaptor
 "      <arg direction=\"out\" type=\"x\" name=\"aPrevSyncTime\"/>\n"
 "      <arg direction=\"out\" type=\"x\" name=\"aNextSyncTime\"/>\n"
 "    </method>\n"
+"    <method name=\"isSyncedExternally\">\n"
+"      <arg direction=\"in\" type=\"u\" name=\"aAccountId\"/>\n"
+"      <arg direction=\"in\" type=\"s\" name=\"aClientProfileName\"/>\n"
+"      <annotation value=\"true\" name=\"org.freedesktop.DBus.Method.NoReply\"/>\n"
+"    </method>\n"
 "  </interface>\n"
         "")
 public:
@@ -186,6 +197,7 @@ public Q_SLOTS: // METHODS
     QStringList syncProfilesByType(const QString &aType);
     QList<uint> syncingAccounts();
     bool updateProfile(const QString &aProfileAsXml);
+    Q_NOREPLY void isSyncedExternally(uint aAccountId, const QString aClientProfileName);
 Q_SIGNALS: // SIGNALS
     void backupDone();
     void backupInProgress();
@@ -196,6 +208,7 @@ Q_SIGNALS: // SIGNALS
     void statusChanged(uint aAccountId, int aNewStatus, int aFailedReason, qlonglong aPrevSyncTime, qlonglong aNextSyncTime);
     void syncStatus(const QString &aProfileName, int aStatus, const QString &aMessage, int aMoreDetails);
     void transferProgress(const QString &aProfileName, int aTransferDatabase, int aTransferType, const QString &aMimeType, int aCommittedItems);
+    void syncedExternallyStatus(uint aAccountId, const QString &aClientProfileName, bool aState);
 };
 
 #endif

--- a/msyncd/SyncDBusInterface.h
+++ b/msyncd/SyncDBusInterface.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -165,6 +166,17 @@ signals:
      * \see SyncCommonDefs::ConnectivityType for arguments
      */
     bool isConnectivityAvailable(int connectivityType);
+
+    /*! \brief Notifies sync externally status for an account and client profile.
+     *
+     * This signal is sent when the sync externally status of a particular
+     * account changes or a client queries for the state via 'isSyncedExternally'
+     *
+     * \param aAccountId The account IDs that changed state/was queried the state
+     * \param aClientProfileName The name of the client profile resposible for the sync.
+     * \param aState The current status of sync externally(on/off).
+     */
+    void syncedExternallyStatus(uint aAccountId, const QString &aClientProfileName, bool aState);
 
 public slots:
 
@@ -351,6 +363,16 @@ public slots:
      * 1 = Last sync succeeded, 2 = last sync failed
      */
     virtual int status(unsigned int aAccountId, int &aFailedReason, qlonglong &aPrevSyncTime, qlonglong &aNextSyncTime) = 0;
+
+    /*! \brief Queries the sync externally status of a given account,
+     * 'syncedExternallyStatus' signal is emitted with the reply is ready, clients should listen
+     * to the later.
+     *
+     * \param aAccountId The account ID.
+     * \param aClientProfileName The name of the client profile resposible for the sync, this is used to distinguish accounts
+     *  having several services enabled
+     */
+    virtual Q_NOREPLY void isSyncedExternally(unsigned int aAccountId, const QString aClientProfileName) = 0;
 };
 
 }

--- a/msyncd/SyncScheduler.cpp
+++ b/msyncd/SyncScheduler.cpp
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *

--- a/msyncd/SyncScheduler.h
+++ b/msyncd/SyncScheduler.h
@@ -140,7 +140,6 @@ private: // functions
      */
     int setNextAlarm(const SyncProfile* aProfile, QDateTime aNextSyncTime = QDateTime());
     
-    
     /**
      * \brief Creates a DBUS adaptor for the scheduler
      */

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -2,6 +2,7 @@
  * This file is part of buteo-syncfw package
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2014-2015 Jolla Ltd
  *
  * Contact: Sateesh Kavuri <sateesh.kavuri@nokia.com>
  *
@@ -210,6 +211,16 @@ public slots:
      */
     int status(unsigned int aAccountId, int &aFailedReason, qlonglong &aPrevSyncTime, qlonglong &aNextSyncTime);
 
+    /*! \brief Queries the sync externally status of a given account,
+     * 'syncedExternallyStatus' signal is emitted with the reply is ready, clients should listen
+     * to the later.
+     *
+     * \param aAccountId The account ID.
+     * \param aClientProfileName The name of the client profile resposible for the sync, this is used to distinguish accounts
+     *  having several services enabled.
+     */
+    void isSyncedExternally(unsigned int aAccountId, const QString aClientProfileName);
+
 signals:
 
         //! emitted by releaseStorages call
@@ -358,7 +369,25 @@ private:
 
     bool clientProfileActive(const QString &clientProfileName);
 
+    /*! \brief Checks the status of external sync for a given profile, when the status
+     * changes(or aQuery param is set to true) or the profile is added for the first time 'syncedExternallyStatus' dbus signal
+     * will be emitted to notify possible clients.
+     *
+     * @param aProfile the profile that the state will be checked
+     * @param aQuery When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
+     */
+    void externalSyncStatus(const SyncProfile *aProfile, bool aQuery=false);
+
+    /*! \brief Removes the external sync status for a given profile, if status changes
+     * 'syncedExternallyStatus' dbus signal will be emitted to notify possible clients.
+     *
+     * @param aProfile the profile that the status should be removed.
+     */
+    void removeExternalSyncStatus(const SyncProfile *aProfile);
+
     QMap<QString, SyncSession*> iActiveSessions;
+
+    QMap<int, bool> iExternalSyncProfileStatus;
 
     QList<QString> iProfilesToRemove;
 

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name: buteo-syncfw-qt5
-Version: 0.7.13
+Version: 0.7.14
 Release: 1
 Summary: Synchronization backend
 Group: System/Libraries


### PR DESCRIPTION
New property for always-up-to-date schedule is introduced, when in this
state, buteo does not perform any syncs, just notifies via dbus of changes
to this property, a external process will be responsible for the syncs.
New property for always-up-to-date rush schedule is introduced, when is a rush
hour and this property is set to true, buteo will not perform syncs until end of
the rush hour, external process will be responsible for the syncs.