### PR TITLE
[buteo-syncfw] Only write profile to disk if changes occur

### DIFF
--- a/libbuteosyncfw/profile/ProfileManager.h
+++ b/libbuteosyncfw/profile/ProfileManager.h
@@ -307,17 +307,20 @@ public:
      * \param aProfile Profile of the remote device
      * \param aStorageMap Map of storage names(hcalendar, hcontacts) and if sync
      * enabled value true/false
-     *
+     * \param aModified Whether the profile was updated as a result of this function call,
+     * and thus requires writing to disk
      */ 
-    void enableStorages (Profile &aProfile, QMap<QString , bool> &aStorageMap); 
+    void enableStorages (Profile &aProfile, QMap<QString , bool> &aStorageMap, bool *aModified = NULL);
    
      /*! \brief Sets storage subprofiles hidden status for the given profile
      *
      * \param aProfile Profile of the remote device
      * \param aStorageMap Map of storage names (hcalendar, hcontacts) and visibility status. With value \e true
      * the storage will be set visible (equals profile attribute hidden=false)
+     * \param aModified Whether the profile was updated as a result of this function call,
+     * and thus requires writing to disk
      */ 
-    void setStoragesVisible(Profile &aProfile, QMap<QString, bool> &aStorageMap);
+    void setStoragesVisible(Profile &aProfile, QMap<QString, bool> &aStorageMap, bool *aModified = NULL);
     
     /*! \brief Sets remote target in profile
      *

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -624,19 +624,21 @@ void Synchronizer::onSessionFinished(const QString &aProfileName,
             {
             case Sync::SYNC_DONE:
             {
+                bool enabledUpdated = false, visibleUpdated = false;
                 QMap<QString,bool> storageMap = session->getStorageMap();
-                //session->setFailureResult(SyncResults::SYNC_RESULT_SUCCESS, Buteo::SyncResults::NO_ERROR);
                 SyncProfile *sessionProf = session->profile();
-                iProfileManager.enableStorages(*sessionProf, storageMap);
+                iProfileManager.enableStorages(*sessionProf, storageMap, &enabledUpdated);
 
                 // If caps have not been modified, i.e. fetched from the remote device yet, set
                 // enabled storages also visible. If caps have been modified, we must not touch visibility anymore
                 if (sessionProf->boolKey(KEY_CAPS_MODIFIED) == false)
                 {
-                    iProfileManager.setStoragesVisible(*sessionProf, storageMap);
+                    iProfileManager.setStoragesVisible(*sessionProf, storageMap, &visibleUpdated);
                 }
 
-                iProfileManager.updateProfile(*sessionProf);
+                if (enabledUpdated || visibleUpdated) {
+                    iProfileManager.updateProfile(*sessionProf);
+                }
                 iProfileManager.retriesDone(sessionProf->name());
                 break;
             }


### PR DESCRIPTION
This commit ensures that the profile values are checked to determine
whether the profile needs to be updated once a sync completes, rather
than assuming that it does and forcing a rewrite.

This means we do less disk I/O and also reduces possibilities for
profile corruption due to I/O errors.