### PR TITLE
[msyncd] Emit externalSyncChanged when going in/out of rush without performing syncs.

### DIFF
--- a/msyncd/BackgroundSync.cpp
+++ b/msyncd/BackgroundSync.cpp
@@ -243,6 +243,9 @@ bool BackgroundSync::setSwitch(const QString &aProfName, const QDateTime &aSwitc
     if(iScheduledSwitch.contains(aProfName) == true) {
         BActivitySwitchStruct &newSwitch = iScheduledSwitch[aProfName];
         if (newSwitch.nextSwitch != aSwitchTime) {
+            // If activity's state was already Waiting, the state doesn't change, nothing happens and
+            // the existing background activity keeps running until the previously set time expires, so we have to stop it.
+            newSwitch.backgroundActivity->stop();
             newSwitch.nextSwitch = aSwitchTime;
             newSwitch.backgroundActivity->wait(QDateTime::currentDateTime().secsTo(aSwitchTime));
             LOG_DEBUG("BackgroundSync::setSwitch(), Rescheduling for " << aProfName << " at " << aSwitchTime.toString());

--- a/msyncd/SyncScheduler.cpp
+++ b/msyncd/SyncScheduler.cpp
@@ -171,6 +171,9 @@ void SyncScheduler::rescheduleBackgroundActivity(const QString& aProfileName)
 
     SyncProfile* profile = iProfileManager.syncProfile(aProfileName);
     if (profile) {
+        if (profile->syncExternallyEnabled() || profile->syncExternallyDuringRush()) {
+            emit externalSyncChanged(profile, false);
+        }
         setNextAlarm(profile);
     } else {
         LOG_WARNING("Invalid profile, can't reschedule switch timer for " << aProfileName);

--- a/msyncd/SyncScheduler.h
+++ b/msyncd/SyncScheduler.h
@@ -129,6 +129,13 @@ signals:
      */
     void syncNow(QString aProfileName);
 
+    /*! \brief Signal emitted when a sync session should be launched based on
+     *   the sync schedule settings of the profile.
+     *
+     * \param aProfileName Name of the profile.
+     */
+    void externalSyncChanged(const SyncProfile* aProfile, bool aQuery=false);
+
 private: // functions
     
     /**

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -1130,6 +1130,8 @@ void Synchronizer::initializeScheduler()
         iSyncScheduler = new SyncScheduler(this);
         connect(iSyncScheduler, SIGNAL(syncNow(QString)),
                 this, SLOT(startScheduledSync(QString)), Qt::QueuedConnection);
+        connect(iSyncScheduler, SIGNAL(externalSyncChanged(const SyncProfile*,bool)),
+                this, SLOT(externalSyncStatus(const SyncProfile*,bool)), Qt::QueuedConnection);
         QList<SyncProfile*> profiles = iProfileManager.allSyncProfiles();
         foreach (SyncProfile *profile, profiles)
         {

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -305,6 +305,15 @@ private slots:
      */
     void removeScheduledSync(const QString &aProfileName);
 
+    /*! \brief Checks the status of external sync for a given profile, when the status
+     * changes(or aQuery param is set to true) or the profile is added for the first time 'syncedExternallyStatus' dbus signal
+     * will be emitted to notify possible clients.
+     *
+     * @param aProfile the profile that the state will be checked
+     * @param aQuery When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
+     */
+    void externalSyncStatus(const SyncProfile *aProfile, bool aQuery=false);
+
 private:
 
     bool startSync(const QString &aProfileName, bool aScheduled);
@@ -368,15 +377,6 @@ private:
     bool cleanupProfile(const QString &profileId);
 
     bool clientProfileActive(const QString &clientProfileName);
-
-    /*! \brief Checks the status of external sync for a given profile, when the status
-     * changes(or aQuery param is set to true) or the profile is added for the first time 'syncedExternallyStatus' dbus signal
-     * will be emitted to notify possible clients.
-     *
-     * @param aProfile the profile that the state will be checked
-     * @param aQuery When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
-     */
-    void externalSyncStatus(const SyncProfile *aProfile, bool aQuery=false);
 
     /*! \brief Removes the external sync status for a given profile, if status changes
      * 'syncedExternallyStatus' dbus signal will be emitted to notify possible clients.


### PR DESCRIPTION
Fixes also background timer switch similar fix to ee0828878623d48cb62b71ed0b5cb705047239e9